### PR TITLE
Fix always-true condition

### DIFF
--- a/basics/dice-roller.py
+++ b/basics/dice-roller.py
@@ -3,7 +3,7 @@ import random
 while True:
     choice = input("Do you want to roll again? (y/n): ")
 
-    if choice == "y" or "Y":
+    if choice == "y" or choice == "Y":
         random_dice_roll = random.randint(1, 6)
         print("Rolling...")
         print(f"Dice Rolled: {random_dice_roll}")


### PR DESCRIPTION
The current condition in `if` statement:  
  
```py  
choice == "y" or "Y":  
```  
  
would always return true, because `"Y"` is a non-empty string.  

Using:  
```py  
choice == "y" or choice == "Y"  
```  
would fix this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected user input handling to ensure dice are only rolled when the user enters "y" or "Y".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->